### PR TITLE
Allow Cursor to be iterated and resources to be serialized with an array

### DIFF
--- a/src/Arrayable.php
+++ b/src/Arrayable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK;
+
+/**
+ * An interface that defines whether or not an object can be transformed to an array
+ *
+ * @since 2016-06-24
+ */
+interface Arrayable
+{
+    /**
+     * Returns an array representation of an object
+     *
+     * @return array
+     */
+    public function toArray();
+}

--- a/src/DateTime/DateTimeFormatter.php
+++ b/src/DateTime/DateTimeFormatter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\DateTime;
+
+/**
+ * A collection of helper functions for string->date conversion
+ *
+ * @since 2016-06-24
+ */
+trait DateTimeFormatter
+{
+    /**
+     * Returns a DateTime object from a date string.
+     *
+     * @param string
+     * @return DateTime
+     */
+    public function toDateTime($datestr)
+    {
+        return (new \DateTime($datestr))->setTimeZone(new \DateTimeZone('UTC'));
+    }
+    /**
+     * Returns an ImmutableDateTime object from a date string.
+     *
+     * @param string
+     * @return DateTimeImmutable
+     */
+    public function toDateTimeImmutable($datestr)
+    {
+        return (new \DateTimeImmutable($datestr))->setTimeZone(new \DateTimeZone('UTC'));
+    }
+}

--- a/src/TwitterAds/Account.php
+++ b/src/TwitterAds/Account.php
@@ -229,25 +229,6 @@ class Account extends Resource
     }
 
     /**
-     * Converts this object to a functional array of attributes
-     *
-     * @return array
-    public function toArray()
-    {
-        return [
-            'id'                    => $this->getId(),
-            'salt'                  => $this->getSalt(),
-            'timezone'              => $this->getTimezone(),
-            'timezone_switch_at'    => $this->getTimezoneSwitchAt(),
-            'created_at'            => $this->getCreatedAt(),
-            'updated_at'            => $this->getUpdatedAt(),
-            'deleted'               => $this->getDeleted(),
-            'approval_status'       => $this->getApprovalStatus(),
-        ];
-    }
-     */
-
-    /**
      * @return string
      */
     public function getId()

--- a/src/TwitterAds/Account.php
+++ b/src/TwitterAds/Account.php
@@ -257,7 +257,7 @@ class Account extends Resource
      */
     public function getTimezoneSwitchAt()
     {
-        return $this->convertDateTime($this->timezone_switch_at);
+        return $this->timezone_switch_at;
     }
 
     /**
@@ -265,7 +265,7 @@ class Account extends Resource
      */
     public function getCreatedAt()
     {
-        return $this->convertDateTime($this->created_at);
+        return $this->created_at;
     }
 
     /**
@@ -273,7 +273,7 @@ class Account extends Resource
      */
     public function getUpdatedAt()
     {
-        return $this->convertDateTime($this->updated_at);
+        return $this->updated_at;
     }
 
     /**
@@ -306,14 +306,5 @@ class Account extends Resource
     public function getName()
     {
         return $this->name;
-    }
-
-    private function convertDateTime($date)
-    {
-        if ($date instanceof \DateTimeImmutable) {
-            return $date;
-        }
-
-        return $this->toDateTimeImmutable($date);
     }
 }

--- a/src/TwitterAds/Account.php
+++ b/src/TwitterAds/Account.php
@@ -232,7 +232,6 @@ class Account extends Resource
      * Converts this object to a functional array of attributes
      *
      * @return array
-     */
     public function toArray()
     {
         return [
@@ -246,6 +245,7 @@ class Account extends Resource
             'approval_status'       => $this->getApprovalStatus(),
         ];
     }
+     */
 
     /**
      * @return string

--- a/src/TwitterAds/Account.php
+++ b/src/TwitterAds/Account.php
@@ -18,6 +18,7 @@ use Hborras\TwitterAdsSDK\TwitterAdsException;
 
 class Account extends Resource
 {
+
     const RESOURCE_REPLACE          = '{account_id}';
     const RESOURCE_COLLECTION       = 'accounts';
     const RESOURCE                  = 'accounts/{account_id}';
@@ -228,6 +229,25 @@ class Account extends Resource
     }
 
     /**
+     * Converts this object to a functional array of attributes
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'id'                    => $this->getId(),
+            'salt'                  => $this->getSalt(),
+            'timezone'              => $this->getTimezone(),
+            'timezone_switch_at'    => $this->getTimezoneSwitchAt(),
+            'created_at'            => $this->getCreatedAt(),
+            'updated_at'            => $this->getUpdatedAt(),
+            'deleted'               => $this->getDeleted(),
+            'approval_status'       => $this->getApprovalStatus(),
+        ];
+    }
+
+    /**
      * @return string
      */
     public function getId()
@@ -252,27 +272,27 @@ class Account extends Resource
     }
 
     /**
-     * @return mixed
+     * @return \DateTimeImmutable
      */
     public function getTimezoneSwitchAt()
     {
-        return $this->timezone_switch_at;
+        return $this->convertDateTime($this->timezone_switch_at);
     }
 
     /**
-     * @return mixed
+     * @return \DateTimeImmutable
      */
     public function getCreatedAt()
     {
-        return $this->created_at;
+        return $this->convertDateTime($this->created_at);
     }
 
     /**
-     * @return mixed
+     * @return \DateTimeImmutable
      */
     public function getUpdatedAt()
     {
-        return $this->updated_at;
+        return $this->convertDateTime($this->updated_at);
     }
 
     /**
@@ -280,7 +300,7 @@ class Account extends Resource
      */
     public function getDeleted()
     {
-        return $this->deleted;
+        return filter_var($this->deleted, FILTER_VALIDATE_BOOLEAN);
     }
 
     /**
@@ -305,5 +325,14 @@ class Account extends Resource
     public function getName()
     {
         return $this->name;
+    }
+
+    private function convertDateTime($date)
+    {
+        if ($date instanceof \DateTimeImmutable) {
+            return $date;
+        }
+
+        return $this->toDateTimeImmutable($date);
     }
 }

--- a/src/TwitterAds/Campaign/AppList.php
+++ b/src/TwitterAds/Campaign/AppList.php
@@ -37,6 +37,16 @@ class AppList extends Resource
         return $this->fromResponse($request->data);
     }
 
+    public function toArray()
+    {
+        return [
+            'id'            => $this->getId(),
+            'name'          => $this->getName(),
+            'apps'          => $this->getApps(),
+            'properties'    => $this->getProperties(),
+        ];
+    }
+
     /**
      * @return mixed
      */

--- a/src/TwitterAds/Campaign/AppList.php
+++ b/src/TwitterAds/Campaign/AppList.php
@@ -37,16 +37,6 @@ class AppList extends Resource
         return $this->fromResponse($request->data);
     }
 
-    public function toArray()
-    {
-        return [
-            'id'            => $this->getId(),
-            'name'          => $this->getName(),
-            'apps'          => $this->getApps(),
-            'properties'    => $this->getProperties(),
-        ];
-    }
-
     /**
      * @return mixed
      */

--- a/src/TwitterAds/Cursor.php
+++ b/src/TwitterAds/Cursor.php
@@ -7,7 +7,7 @@
  */
 namespace Hborras\TwitterAdsSDK\TwitterAds;
 
-class Cursor
+class Cursor implements \IteratorAggregate
 {
     private $account;
     /** @var Resource  */
@@ -134,6 +134,14 @@ class Cursor
         }
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->collection);
     }
 
     /**

--- a/src/TwitterAds/Resource.php
+++ b/src/TwitterAds/Resource.php
@@ -4,6 +4,7 @@ namespace Hborras\TwitterAdsSDK\TwitterAds;
 
 use Hborras\TwitterAdsSDK\ServerError;
 use Hborras\TwitterAdsSDK\TwitterAdsException;
+use Hborras\TwitterAdsSDK\Arrayable;
 
 /**
  * Created by PhpStorm.
@@ -11,7 +12,7 @@ use Hborras\TwitterAdsSDK\TwitterAdsException;
  * Date: 2/04/16
  * Time: 12:17.
  */
-abstract class Resource
+abstract class Resource implements Arrayable
 {
     use \Hborras\TwitterAdsSDK\DateTime\DateTimeFormatter;
 
@@ -103,7 +104,7 @@ abstract class Resource
     public function fromResponse($response)
     {
         foreach (get_object_vars($response) as $key => $value) {
-            if (($key == 'created_at' || $key == 'updated_at' || $key == 'start_time' || $key == 'end_time') && !is_null($value)) {
+            if (($key == 'created_at' || $key == 'updated_at' || $key == 'start_time' || $key == 'end_time' || $key == 'timezone_switch_at') && !is_null($value)) {
                 $this->$key = $this->toDateTimeImmutable($value);
             } else {
                 $this->$key = $value;
@@ -143,6 +144,21 @@ abstract class Resource
         if (!$this->getId()) {
             throw new ServerError(TwitterAdsException::SERVER_ERROR, "Error loading entity", null, null);
         }
+    }
+
+    public function toArray()
+    {
+        $data = [];
+        $vars = get_object_vars($this);
+
+        foreach ($vars as $key => $var) {
+            if ($var instanceof $this) {
+                continue;
+            }
+            $data[$key] = $var;
+        }
+
+        return $data;
     }
 
     public function loadResource(Account $account, $id = '', $params = [])

--- a/src/TwitterAds/Resource.php
+++ b/src/TwitterAds/Resource.php
@@ -2,7 +2,6 @@
 
 namespace Hborras\TwitterAdsSDK\TwitterAds;
 
-use DateTime;
 use Hborras\TwitterAdsSDK\ServerError;
 use Hborras\TwitterAdsSDK\TwitterAdsException;
 
@@ -14,6 +13,8 @@ use Hborras\TwitterAdsSDK\TwitterAdsException;
  */
 abstract class Resource
 {
+    use \Hborras\TwitterAdsSDK\DateTime\DateTimeFormatter;
+
     const RESOURCE            = '';
     const RESOURCE_COLLECTION = '';
     const RESOURCE_ID_REPLACE = '{id}';
@@ -103,7 +104,7 @@ abstract class Resource
     {
         foreach (get_object_vars($response) as $key => $value) {
             if (($key == 'created_at' || $key == 'updated_at' || $key == 'start_time' || $key == 'end_time') && !is_null($value)) {
-                $this->$key = new DateTime($value);
+                $this->$key = $this->toDateTimeImmutable($value);
             } else {
                 $this->$key = $value;
             }

--- a/tests/TwitterAds/AccountTest.php
+++ b/tests/TwitterAds/AccountTest.php
@@ -26,6 +26,28 @@ class AccountTest extends \PHPUnit_Framework_TestCase
         $this->twitter = new TwitterAds(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET, false);
     }
 
+    public function testAccountsCanBeConvertedToAnArray()
+    {
+        $types = [
+            'id'                    => function($v) { return is_string($v); },
+            'salt'                  => function($v) { return is_string($v); },
+            'timezone'              => function($v) { return is_string($v); },
+            'timezone_switch_at'    => function($v) { return $v instanceof \DateTimeImmutable; },
+            'created_at'            => function($v) { return $v instanceof \DateTimeImmutable; },
+            'updated_at'            => function($v) { return $v instanceof \DateTimeImmutable; },
+            'deleted'               => function($v) { return is_bool($v); },
+            'approval_status'       => function($v) { return is_string($v); },
+        ];
+        $accounts = $this->twitter->getAccounts();
+
+        foreach($accounts as $account) {
+            $array = $account->toArray();
+            foreach ($array as $key => $value) {
+                $this->assertTrue($types[$key]($value));
+            }
+        }
+    }
+
     /**
      * @return Account|Cursor
      */

--- a/tests/TwitterAds/AccountTest.php
+++ b/tests/TwitterAds/AccountTest.php
@@ -30,13 +30,15 @@ class AccountTest extends \PHPUnit_Framework_TestCase
     {
         $types = [
             'id'                    => function($v) { return is_string($v); },
+            'name'                  => function($v) { return is_string($v); },
             'salt'                  => function($v) { return is_string($v); },
             'timezone'              => function($v) { return is_string($v); },
-            'timezone_switch_at'    => function($v) { return $v instanceof \DateTimeImmutable; },
-            'created_at'            => function($v) { return $v instanceof \DateTimeImmutable; },
-            'updated_at'            => function($v) { return $v instanceof \DateTimeImmutable; },
+            'timezone_switch_at'    => function($v) { return $v instanceof \DateTimeInterface; },
+            'created_at'            => function($v) { return $v instanceof \DateTimeInterface; },
+            'updated_at'            => function($v) { return $v instanceof \DateTimeInterface; },
             'deleted'               => function($v) { return is_bool($v); },
             'approval_status'       => function($v) { return is_string($v); },
+            'properties'            => function($v) { return is_array($v); },
         ];
         $accounts = $this->twitter->getAccounts();
 


### PR DESCRIPTION
This PR adds the ability to Cursor object to be iterated in PHP.
```php
foreach ($cursor as $elements) {
    //Do something
}
```
 Also implements a method for all `Resource` types to convert the variables to an array through an `Arrayable` interface. This is helpful for users to implement their own service objects for the twitter responses.

```php
$accounts = $twitter->getAccounts();
return $accounts->toArray();
```
```
[
  'id' => 'xxx',
  'salt' => 'xxx',
  'name' => 'test',
  'timezone' = 'xxx',
  'timezone_switch_at' => (DateTimeImmutable),
  'created_at' => (DateTimeImmutable),
  'updated_at' => (DateTimeImmutable),
  'delete' => false,
  'approval_status' => 'xxx',
  'properties' => []
]
```
