### PR TITLE
Tailored Audiences

### DIFF
--- a/examples/tailored_audience_memberships.php
+++ b/examples/tailored_audience_memberships.php
@@ -1,0 +1,35 @@
+<?php
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\TailoredAudienceMemberships;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\TailoredAudienceMember;;
+
+require '../autoload.php';
+
+const CONSUMER_KEY = 'your consumer key';
+const CONSUMER_SECRET = 'your consumer secret';
+const ACCESS_TOKEN = 'your access token';
+const ACCESS_TOKEN_SECRET = 'your access token secret';
+const ACCOUNT_ID = 'account id';
+
+// Create twitter ads client
+$twitterAds = new TwitterAds(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET);
+
+$batch = new TailoredAudienceMemberships($account);
+
+for ($i = 0; $i < 101; $i++) {
+    $member = new TailoredAudienceMember();
+    //Replace these values with correct ones from
+    //https://dev.twitter.com/ads/reference/post/tailored_audience_memberships
+    $member->setScore($i);
+    $member->setUserIdentifier($i);
+    $member->setAdvertiserAccountId(self::ACCOUNT_ID);
+    $member->setUserIdentifierType(TailoredAudienceMember::TYPE_TAWEB_PARTNER_USER_ID);
+    $member->setAudienceNames([
+        'test1',
+        'test2',
+    ]);
+    $batch->add($member);
+}
+
+$batch->save();

--- a/src/TwitterAds/Batch.php
+++ b/src/TwitterAds/Batch.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds;
+
+use Hborras\TwitterAdsSDK\TwitterAds\Resource;
+use Hborras\TwitterAdsSDK\TwitterAds\Account;
+use Hborras\TwitterAdsSDK\Arrayable;
+use Hborras\TwitterAdsSDK\TwitterAds\Errors\BatchLimitExceeded;
+
+abstract class Batch extends Resource
+{
+    private $batch = [];
+    private $batchSize;
+    private $account;
+
+    public function __construct(Account $account=null, $batchSize=10,  $batch=[])
+    {
+        parent::__construct($account);
+        $this->account = $account;
+        $this->batchSize = $batchSize;
+        $this->batch = $this->assureBatchSize($batch);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        //Always use POST request by setting the ID to null
+        return null;
+    }
+
+    public function getAccount()
+    {
+        return $this->account;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toParams()
+    {
+        $data = [];
+
+        foreach ($this->batch as $member) {
+            $data[] = $member->toArray();
+        }
+
+        return $data;
+    }
+    
+    public function getBatch()
+    {
+        return $this->batch;
+    }
+
+    public function add(Arrayable $data)
+    {
+        $this->assureBatchSize();
+
+        $this->batch[] = $data;
+    }
+
+    /**
+     * Assures the batch is not over the batch size limit.
+     *
+     * @param $batch|null
+     *
+     * @throws BatchLimitExceeded when the batch is full
+     * @return $batch|$this->batch
+     */
+    public function assureBatchSize($batch=null)
+    {
+        if (count($batch ?: $this->batch) < $this->batchSize) {
+            return $batch ?: $this->batch;
+        }
+
+        throw new BatchLimitExceeded(sprintf(
+            'Cannot add data to batch. Max size is %s',
+            $this->batchSize
+        ));
+    }
+}

--- a/src/TwitterAds/Errors/BatchLimitExceeded.php
+++ b/src/TwitterAds/Errors/BatchLimitExceeded.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds\Errors;
+
+final class BatchLimitExceeded extends \DomainException
+{
+    //noop
+}

--- a/src/TwitterAds/Resource.php
+++ b/src/TwitterAds/Resource.php
@@ -125,7 +125,7 @@ abstract class Resource implements Arrayable
             if (is_null($this->$property)) {
                 continue;
             }
-            if ($this->$property instanceof DateTime) {
+            if ($this->$property instanceof \DateTimeInterface) {
                 $params[$property] = $this->$property->format('c');
             } elseif (is_array($this->$property)) {
                 $params[$property] = implode(',', $this->$property);

--- a/src/TwitterAds/TailoredAudience/Exception/InvalidOperation.php
+++ b/src/TwitterAds/TailoredAudience/Exception/InvalidOperation.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception;
+
+final class InvalidOperation extends \DomainException
+{
+    //noop
+}

--- a/src/TwitterAds/TailoredAudience/Exception/InvalidType.php
+++ b/src/TwitterAds/TailoredAudience/Exception/InvalidType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception;
+
+final class InvalidType extends \DomainException
+{
+    //noop
+}

--- a/src/TwitterAds/TailoredAudience/GlobalOptOut.php
+++ b/src/TwitterAds/TailoredAudience/GlobalOptOut.php
@@ -7,6 +7,11 @@ use Hborras\TwitterAdsSDK\TwitterAds\Resource;
 use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception\InvalidType;
 use Hborras\TwitterAdsSDK\Arrayable;
 
+/**
+ * Updates a list of user's optout status
+ *
+ * @since 2016-06-27
+ */
 final class GlobalOptOut extends Resource
 {
     const RESOURCE = 'accounts/{account_id}/tailored_audiences/{route}';
@@ -76,5 +81,13 @@ final class GlobalOptOut extends Resource
         throw new InvalidType(
             sprintf('"%s" is not a valid type for %s', $type, TailoredAudience::class)
         );
+    }
+
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        return $this->properties;
     }
 }

--- a/src/TwitterAds/TailoredAudience/GlobalOptOut.php
+++ b/src/TwitterAds/TailoredAudience/GlobalOptOut.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience;
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\Resource;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception\InvalidType;
+use Hborras\TwitterAdsSDK\Arrayable;
+
+final class GlobalOptOut extends Resource
+{
+    const RESOURCE = 'accounts/{account_id}/tailored_audiences/{route}';
+
+    // This is a hack to allow PUT requests for an entity without an ID
+    const RESOURCE_ID_REPLACE = '{route}';
+    const ROUTE = 'global_opt_out';
+
+    protected $input_file_path;
+    protected $list_type;
+
+    protected $properties = [
+        'input_file_path',
+        'list type',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return self::ROUTE;
+    }
+
+    public function getInputFilePath()
+    {
+        return $this->input_file_path;
+    }
+
+    public function setInputFilePath($path)
+    {
+        $this->input_file_path = $path;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getListType()
+    {
+        return $this->assureValidType($this->list_type);
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setListType($type)
+    {
+        $this->list_type = $this->assureValidType($type);
+    }
+
+    /**
+     * Asserts that the given type is valid
+     *
+     * @param string $type
+     * @throws InvalidType - if type is invalid or null
+     *
+     * @return string
+     */
+    private function assureValidType($type)
+    {
+        foreach (TailoredAudience::getTypes() as $allowedType) {
+            if ($type === $allowedType) {
+                return $type;
+            }
+        }
+
+        throw new InvalidType(
+            sprintf('"%s" is not a valid type for %s', $type, TailoredAudience::class)
+        );
+    }
+}

--- a/src/TwitterAds/TailoredAudience/TailoredAudience.php
+++ b/src/TwitterAds/TailoredAudience/TailoredAudience.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience;
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\Account;
+use Hborras\TwitterAdsSDK\TwitterAds\Resource;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception\InvalidType;
+
+final class TailoredAudience extends Resource
+{
+    const RESOURCE_COLLECTION = 'accounts/{account_id}/tailored_audiences';
+    const RESOURCE = 'accounts/{account_id}/tailored_audiences/{id}';
+
+    const LIST_TYPE_EMAIL = 'EMAIL';
+    const LIST_TYPE_DEVICE_ID = 'DEVICE_ID';
+    const LIST_TYPE_TWITTER_ID = 'TWITTER_ID';
+    const LIST_TYPE_HANDLE = 'HANDLE';
+    const LIST_TYPE_PHONE_NUMBER = 'PHONE_NUMBER';
+
+    /** Writable */
+    protected $list_type;
+    protected $name;
+
+    protected $properties = [
+        'name',
+        'list_type',
+    ];
+
+    /** Read Only */
+    protected $deleted;
+    protected $targetable;
+    protected $audience_size;
+    protected $id;
+    protected $updated_at;
+    protected $created_at;
+    protected $audience_type;
+    protected $reasons_not_targetable;
+    protected $targetable_types;
+    protected $partner_source;
+
+    public function __construct(Account $account=null, $id=null)
+    {
+        parent::__construct($account);
+        $this->id = $id;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isDeleted()
+    {
+        return filter_var($this->deleted, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isTargetable()
+    {
+        return filter_var($this->targetable, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * @return integer
+     */
+    public function getAudienceSize()
+    {
+        return intval($this->audience_size);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getCreatedAt()
+    {
+        return $this->created_at;
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updated_at;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getListType()
+    {
+        return $this->assureValidType($this->list_type);
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setListType($type)
+    {
+        $this->list_type = $this->assureValidType($type);
+    }
+
+    /**
+     * @return string
+     */
+    public function getAudienceType()
+    {
+        return $this->audience_type;
+    }
+
+    /**
+     * @return array
+     */
+    public function getReasonsNotTargetable()
+    {
+        return $this->reasons_not_targetable;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTargetableTypes()
+    {
+        return $this->targetable_types;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPartnerSource()
+    {
+        return $this->partner_source;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getTypes()
+    {
+        return [
+            self::LIST_TYPE_DEVICE_ID,
+            self::LIST_TYPE_EMAIL,
+            self::LIST_TYPE_HANDLE,
+            self::LIST_TYPE_PHONE_NUMBER,
+            self::LIST_TYPE_TWITTER_ID,
+        ];
+    }
+
+    /**
+     * Asserts that the given type is valid
+     *
+     * @param string $type
+     * @throws InvalidType - if type is invalid or null
+     *
+     * @return string
+     */
+    private function assureValidType($type)
+    {
+        foreach (self::getTypes() as $allowedType) {
+            if ($type === $allowedType) {
+                return $type;
+            }
+        }
+
+        throw new InvalidType(
+            sprintf('"%s" is not a valid type for %s', $type, TailoredAudience::class)
+        );
+    }
+}

--- a/src/TwitterAds/TailoredAudience/TailoredAudience.php
+++ b/src/TwitterAds/TailoredAudience/TailoredAudience.php
@@ -46,17 +46,6 @@ final class TailoredAudience extends Resource
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function delete()
-    {
-        $resource = str_replace(static::RESOURCE_REPLACE, $this->getAccount()->getId(), static::RESOURCE);
-        $resource = str_replace(static::RESOURCE_ID_REPLACE, $this->getId(), $resource);
-        $request = $this->getAccount()->getTwitterAds()->delete($resource, $this->toParams());
-        $this->fromResponse($request->data);
-    }
-
-    /**
      * @return boolean
      */
     public function isDeleted()

--- a/src/TwitterAds/TailoredAudience/TailoredAudience.php
+++ b/src/TwitterAds/TailoredAudience/TailoredAudience.php
@@ -46,6 +46,17 @@ final class TailoredAudience extends Resource
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function delete()
+    {
+        $resource = str_replace(static::RESOURCE_REPLACE, $this->getAccount()->getId(), static::RESOURCE);
+        $resource = str_replace(static::RESOURCE_ID_REPLACE, $this->getId(), $resource);
+        $request = $this->getAccount()->getTwitterAds()->delete($resource, $this->toParams());
+        $this->fromResponse($request->data);
+    }
+
+    /**
      * @return boolean
      */
     public function isDeleted()
@@ -190,5 +201,13 @@ final class TailoredAudience extends Resource
         throw new InvalidType(
             sprintf('"%s" is not a valid type for %s', $type, TailoredAudience::class)
         );
+    }
+
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        return $this->properties;
     }
 }

--- a/src/TwitterAds/TailoredAudience/TailoredAudienceChanges.php
+++ b/src/TwitterAds/TailoredAudience/TailoredAudienceChanges.php
@@ -67,6 +67,14 @@ final class TailoredAudienceChanges extends Resource
         $this->operation = $this->assureValidOperation($op);
     }
 
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+
     private function getOperations()
     {
         return [

--- a/src/TwitterAds/TailoredAudience/TailoredAudienceChanges.php
+++ b/src/TwitterAds/TailoredAudience/TailoredAudienceChanges.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience;
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\Resource;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception\InvalidOperation;
+
+/**
+ * Represents a Tailored Audience Change object
+ * Supports: GET, POST
+ *
+ * @since 2016-06-27
+ */
+final class TailoredAudienceChanges extends Resource
+{
+    const RESOURCE_COLLECTION = 'accounts/{account_id}/tailored_audiences_changes';
+    const RESOURCE = 'accounts/{account_id}/tailored_audiences_changes/{id}';
+
+    const ADD = 'ADD';
+    const REMOVE = 'REMOVE';
+    const REPLACE = 'REPLACE';
+
+    protected $input_file_path;
+    protected $tailored_audience_id;
+    protected $id;
+    protected $operation;
+
+    protected $properties = [
+        'tailored_audience_id',
+        'input_file_path',
+        'operation',
+    ];
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getInputFilePath()
+    {
+        return $this->input_file_path;
+    }
+
+    public function setInputFilePath($path)
+    {
+        $this->input_file_path = $path;
+    }
+
+    public function getTailoredAudienceId()
+    {
+        return $this->tailored_audience_id;
+    }
+
+    public function setTailoredAudienceId($id)
+    {
+        $this->tailored_audience_id = $id;
+    }
+
+    public function getOperation()
+    {
+        return $this->assureValidOperation($this->operation);
+    }
+
+    public function setOperation($op)
+    {
+        $this->operation = $this->assureValidOperation($op);
+    }
+
+    private function getOperations()
+    {
+        return [
+            self::ADD,
+            self::REMOVE,
+            self::REPLACE,
+        ];
+    }
+    private function assureValidOperation($op)
+    {
+        foreach ($this->getOperations() as $allowedOp) {
+            if ($op === $allowedOp) {
+                return $op;
+            }
+        }
+
+        throw new InvalidOperation(
+            sprintf('"%s" is not a valid operation for %s', $op, TailoredAudience::class)
+        );
+    }
+}

--- a/src/TwitterAds/TailoredAudience/TailoredAudienceMember.php
+++ b/src/TwitterAds/TailoredAudience/TailoredAudienceMember.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience;
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\Arrayable;
+
+/**
+ * Represents a Tailored Audience member
+ *
+ * @since 2016-06-27
+ */
+final class TailoredAudienceMember implements Arrayable
+{
+    const TYPE_TAWEB_PARTNER_USER_ID = 'TAWEB_PARTNER_USER_ID';
+
+    protected $advertiser_account_id;
+    protected $user_identifier;
+    protected $user_identifier_type = self::TYPE_TAWEB_PARTNER_USER_ID;
+    protected $score = 0;
+    protected $audience_names = [];
+    protected $effective_at;
+    protected $expires_at;
+
+    protected $properties = [
+        'advertiser_account_id',
+        'user_identifier',
+        'user_identifier_type',
+        'score',
+        'audience_names',
+        'effective_at',
+        'expires_at',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return null;
+    }
+
+    public function getAdvertiserAccountId()
+    {
+        return $this->advertiser_account_id;
+    }
+
+    public function setAdvertiserAccountId($id)
+    {
+        return $this->advertiser_account_id = $id;
+    }
+
+    public function getUserIdentifier()
+    {
+        return $this->user_identifier;
+    }
+
+    public function setUserIdentifier($id)
+    {
+        return $this->user_identifier = $id;
+    }
+
+    public function getUserIdentifierType()
+    {
+        return $this->user_identifier_type;
+    }
+
+    public function setUserIdentifierType($type)
+    {
+        $this->user_identifier_type = $type;
+    }
+
+    public function getScore()
+    {
+        return $this->score;
+    }
+
+    public function setScore(int $score)
+    {
+        $this->score = $score;
+    }
+
+    public function getAudienceNames()
+    {
+        return implode(', ', $this->audience_names);
+    }
+
+    public function setAudienceNames(array $names)
+    {
+        $this->audience_names =  explode(', ', $names);
+    }
+
+    public function getEffectiveAt()
+    {
+        return $this->effective_at;
+    }
+
+    public function setEffectiveAt(\DateTimeInterface $date)
+    {
+        $this->effective_at = $date;
+    }
+
+    public function getExpiresAt()
+    {
+        return $this->expires_at;
+    }
+
+    public function setExpiresAt(\DateTimeInterface $date)
+    {
+        $this->expires_at = $date;
+    }
+
+    public function toArray()
+    {
+        return [
+            'advertiser_account_id' => $this->getAdvertiserAccountId(),
+            'user_identifier'       => $this->getUserIdentifier(),
+            'user_identifier_type'  => $this->getUserIdentifierType(),
+            'score'                 => $this->getScore(),
+            'audience_names'        => $this->getAudienceNames(),
+            'effective_at'          => $this->getEffectiveAt(),
+            'expires_at'            => $this->getExpiresAt(),
+        ];
+    }
+}

--- a/src/TwitterAds/TailoredAudience/TailoredAudienceMember.php
+++ b/src/TwitterAds/TailoredAudience/TailoredAudienceMember.php
@@ -122,4 +122,12 @@ final class TailoredAudienceMember implements Arrayable
             'expires_at'            => $this->getExpiresAt(),
         ];
     }
+
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        return $this->properties;
+    }
 }

--- a/src/TwitterAds/TailoredAudience/TailoredAudienceMemberships.php
+++ b/src/TwitterAds/TailoredAudience/TailoredAudienceMemberships.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience;
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\Account;
+use Hborras\TwitterAdsSDK\TwitterAds\Batch;
+
+/**
+ * Represents a Tailored Audience membership batch
+ * Supports: POST
+ *
+ * @since 2016-06-27
+ */
+final class TailoredAudienceMemberships extends Batch
+{
+    const MAX_BATCH_SIZE = 100;
+    const RESOURCE = 'tailored_audience_memberships';
+    const OPERATION = 'Update';
+
+    public function __construct(Account $account=null, $members=[])
+    {
+        parent::__construct($account, self::MAX_BATCH_SIZE, $members);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save()
+    {
+        return $this->fromResponse(
+            $this->getAccount()->getTwitterAds()->post(self::RESOURCE, [
+                'operation_type' => self::OPERATION,
+                'params'         => $this->toParams(),
+        ]));
+    }
+}

--- a/tests/TwitterAds/TailoredAudience/GlobalOptOutTest.php
+++ b/tests/TwitterAds/TailoredAudience/GlobalOptOutTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\Account;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\TailoredAudience;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\GlobalOptOut;
+
+class GlobalOptOutTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var TwitterAds */
+    protected $twitter;
+    private $account;
+
+    /**
+     * @expectedException Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception\InvalidType
+     */
+    public function testTailoredAudiencesWillThrowAnExceptionWithAnInvalidType()
+    {
+        $audience = new TailoredAudience(null);
+        $audience->setListType('nope');
+    }
+
+    public function testHackedUrlWillGenerateTheExpectedRoute()
+    {
+        $twitterAds = $this->getMockBuilder(TwitterAds::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $account = new Account($twitterAds);
+        $url = sprintf('accounts/%s/tailored_audiences/global_opt_out', $account->getId());
+
+        $optout = new GlobalOptOut($account);
+        $optout->setListType(TailoredAudience::LIST_TYPE_EMAIL);
+
+        $data = (object)['data' => (object) [
+            'input_file_path' => 'test',
+            'list type' => TailoredAudience::LIST_TYPE_EMAIL,
+        ]];
+        $twitterAds->expects($this->once())
+            ->method('put')
+            ->with($url, $optout->toParams())
+            ->willReturn($data);
+
+        $optout->save();
+    }
+
+    public function testTailoredAudienceGlobalOptOutCanBeUpdatedSuccessfully()
+    {
+        $this->markTestSkipped('waiting for write access to twitter ads api');
+        $audience = new GlobalOptOut(null);
+        $audience->setListType(TailoredAudience::LIST_TYPE_EMAIL);
+        $audience->save();
+    }
+
+    protected function setUp()
+    {
+        $this->twitter = new TwitterAds(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET, false);
+        $this->account = $this->getAccount();
+    }
+
+    private function getAccount()
+    {
+        $accounts = $this->twitter->getAccounts();
+        $this->assertGreaterThan(0, count($accounts));
+        return iterator_to_array($accounts)[0];
+    }
+}

--- a/tests/TwitterAds/TailoredAudience/TailoredAudienceChanges.php
+++ b/tests/TwitterAds/TailoredAudience/TailoredAudienceChanges.php
@@ -1,0 +1,38 @@
+<?php
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\TailoredAudienceChanges;
+use Hborras\TwitterAdsSDK\TwitterAds\Campaign\Campaign;
+use Hborras\TwitterAdsSDK\TwitterAds\Cursor;
+
+class TailoredAudienceChangesTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var TwitterAds */
+    protected $twitter;
+
+    /**
+     * @expectedException Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception\InvalidOperation
+     */
+    public function testTailoredAudienceChangesWillThrowAnExceptionWithAnInvalidOperation()
+    {
+        $audience = new TailoredAudienceChanges(null);
+        $audience->setOperation('nope');
+    }
+
+    public function testTailoredAudienceChangesCanBeFetchedAndUpdated()
+    {
+        $this->markTestSkipped('waiting for write access to twitter ads api');
+        $accounts = $this->twitter->getAccounts();
+        $this->assertGreaterThan(0, count($accounts));
+
+        $account = iterator_to_array($accounts)[0];
+        $audience = new TailoredAudience($account);
+        $audience->setListType(TailoredAudience::LIST_TYPE_EMAIL);
+        $audience->save();
+    }
+
+    protected function setUp()
+    {
+        $this->twitter = new TwitterAds(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET, false);
+    }
+}

--- a/tests/TwitterAds/TailoredAudience/TailoredAudienceMembershipsTest.php
+++ b/tests/TwitterAds/TailoredAudience/TailoredAudienceMembershipsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\TailoredAudienceMemberships;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\TailoredAudienceMember;
+use Hborras\TwitterAdsSDK\TwitterAds\Account;
+
+class TailoredAudienceChangesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Hborras\TwitterAdsSDK\TwitterAds\Errors\BatchLimitExceeded
+     */
+    public function testBatchWillThrowExceptionWhenTooManyMembersAreAdded()
+    {
+        $batch = new TailoredAudienceMemberships();
+
+        for ($i = 0; $i < 101; $i++) {
+            $member = new TailoredAudienceMember();
+            $member->setScore($i);
+            $batch->add($member);
+        }
+    }
+
+    public function testBatchParametersAndUrlAreSetCorrectlyForRequest()
+    {
+        $twitterAds = $this->getMockBuilder(TwitterAds::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $account = new Account($twitterAds);
+        $url = 'tailored_audience_memberships';
+
+        $batch = new TailoredAudienceMemberships($account);
+        for ($i = 0; $i < 10; $i++) {
+            $member = new TailoredAudienceMember();
+            $member->setScore($i);
+            $batch->add($member);
+        }
+
+        $data = (object)['data' => (object) []];
+        $twitterAds->expects($this->once())
+            ->method('post')
+            ->with($url, ['operation_type' => TailoredAudienceMemberships::OPERATION, 'params' => $batch->toParams()])
+            ->willReturn($data);
+
+        $batch->save();
+    }
+}

--- a/tests/TwitterAds/TailoredAudience/TailoredAudienceTest.php
+++ b/tests/TwitterAds/TailoredAudience/TailoredAudienceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Hborras\TwitterAdsSDK\TwitterAds;
+use Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\TailoredAudience;
+
+class TailoredAudienceTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var TwitterAds */
+    protected $twitter;
+    private $account;
+
+    /**
+     * @expectedException Hborras\TwitterAdsSDK\TwitterAds\TailoredAudience\Exception\InvalidType
+     */
+    public function testTailoredAudiencesWillThrowAnExceptionWithAnInvalidType()
+    {
+        $audience = new TailoredAudience(null);
+        $audience->setListType('nope');
+    }
+
+    public function testTailoredAudiencesCanBeAddedSuccessfully()
+    {
+        $this->markTestSkipped('waiting for write access to twitter ads api');
+        $audience = new TailoredAudience($this->account);
+        $audience->setListType(TailoredAudience::LIST_TYPE_EMAIL);
+        $audience->save();
+    }
+
+    public function testTailoredAudiencesCanBeFetched()
+    {
+        $audience = new TailoredAudience($this->account);
+        $result = iterator_to_array($audience->all());
+
+        $this->assertGreaterThan(0, $result);
+    }
+
+    public function testTailoredAudiencesCanBeRemoved()
+    {
+        $this->markTestSkipped('waiting for write access to twitter ads api');
+    }
+
+    protected function setUp()
+    {
+        $this->twitter = new TwitterAds(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET, false);
+        $this->account = $this->getAccount();
+    }
+
+    private function getAccount()
+    {
+        $accounts = $this->twitter->getAccounts();
+        $this->assertGreaterThan(0, count($accounts));
+        return iterator_to_array($accounts)[0];
+    }
+}

--- a/tests/TwitterAds/TailoredAudience/TailoredAudienceTest.php
+++ b/tests/TwitterAds/TailoredAudience/TailoredAudienceTest.php
@@ -18,12 +18,19 @@ class TailoredAudienceTest extends \PHPUnit_Framework_TestCase
         $audience->setListType('nope');
     }
 
-    public function testTailoredAudiencesCanBeAddedSuccessfully()
+    public function testTailoredAudiencesCanBeAddedFetchedAndDeletedSuccessfully()
     {
-        $this->markTestSkipped('waiting for write access to twitter ads api');
         $audience = new TailoredAudience($this->account);
         $audience->setListType(TailoredAudience::LIST_TYPE_EMAIL);
-        $audience->save();
+        $audience->setName('test audience');
+        $newAudience = $audience->save();
+
+        $fetched = (new TailoredAudience($this->account))->load($newAudience->getId());
+        $this->assertEquals($fetched->getId(), $newAudience->getId());
+        $this->assertEquals($fetched->getName(), $newAudience->getName());
+        $this->assertEquals($fetched->getListType(), $newAudience->getListType());
+
+        $fetched->delete();
     }
 
     public function testTailoredAudiencesCanBeFetched()
@@ -32,11 +39,6 @@ class TailoredAudienceTest extends \PHPUnit_Framework_TestCase
         $result = iterator_to_array($audience->all());
 
         $this->assertGreaterThan(0, $result);
-    }
-
-    public function testTailoredAudiencesCanBeRemoved()
-    {
-        $this->markTestSkipped('waiting for write access to twitter ads api');
     }
 
     protected function setUp()


### PR DESCRIPTION
This PR contains functionality for the `Tailored Audiences` portion of the Twitter Ads API.

**This is not complete yet. Please do not merge**
I only have read access to the twitter ads API right now, so I cannot test the creation/deletion of the tailored audiences stuff :cry: I have applied for write access and am just waiting for approval.

TODO:
- Implement the `batch/accounts/:account_id/tailored_audiences` endpoint.
- Write more tests
- Write more documentation and finish out docblocks