### PR TITLE
Now allows Jobs to be read from multiple accounts.

### DIFF
--- a/src/TwitterAds/Analytics/Job.php
+++ b/src/TwitterAds/Analytics/Job.php
@@ -34,7 +34,13 @@ class Job extends Analytics
 
     public function read($params = [])
     {
-        $resource = str_replace(static::RESOURCE_REPLACE, $this->getTwitterAds()->getAccountId(), static::RESOURCE);
+        if (isset($params[JobFields::ACCOUNT_ID])) {
+            $account_id = $params[JobFields::ACCOUNT_ID];
+        } else {
+            $account_id = $this->getTwitterAds()->getAccountId();
+        }
+
+        $resource = str_replace(static::RESOURCE_REPLACE, $account_id, static::RESOURCE);
         $params[JobFields::JOB_IDS] = $this->id;
         $response = $this->getTwitterAds()->get($resource, $params);
         if (isset($response->getBody()->data[0])) {


### PR DESCRIPTION
If an Account ID is provided, use that instead of the one defined in the TwitterAds object.

As it is right now, it is not possible to retrieve jobs from multiple accounts, only from the 'main one', since it is the one being referenced in the TwitterAds object.